### PR TITLE
Restructured the /leaveall output to be more compact

### DIFF
--- a/cogs/ranked.py
+++ b/cogs/ranked.py
@@ -656,7 +656,6 @@ class Ranked(commands.Cog):
             f"Queue for __{qdata.full_game_name}__ is now **[{qdata.queue.qsize()}/{qdata.game_size}]**",
             delete_after=60)
 
-    @app_commands.choices(game=games_choices)
     @app_commands.command(name="leaveall", description="Remove yourself from all queues")
     async def leaveall(self, interaction: discord.Interaction):
         logger.info(f"{interaction.user.name} called /leaveall")

--- a/cogs/ranked.py
+++ b/cogs/ranked.py
@@ -666,6 +666,7 @@ class Ranked(commands.Cog):
                 isinstance(interaction.user, discord.Member) and
                 interaction.channel.id == QUEUE_CHANNEL):
             player = interaction.user
+            message = ""
             dequeued = []
             for game in game_queues.values():
                 qdata = game

--- a/cogs/ranked.py
+++ b/cogs/ranked.py
@@ -666,15 +666,15 @@ class Ranked(commands.Cog):
                 isinstance(interaction.user, discord.Member) and
                 interaction.channel.id == QUEUE_CHANNEL):
             player = interaction.user
-            message = ""
+            cleaned_display_name = ''.join(char for char in player.display_name if char.isalnum())
+            message = f"🔴 **{cleaned_display_name}** 🔴\nremoved from the queue for "
             dequeued = []
             for game in game_queues.values():
                 qdata = game
                 if player in qdata.queue:
                     qdata.queue.remove(player)
                     # old update_ranked_display location
-                    cleaned_display_name = ''.join(char for char in player.display_name if char.isalnum())
-                    message += f"🔴 **{cleaned_display_name}** 🔴\nremoved from the queue for __{qdata.full_game_name}__. *({qdata.queue.qsize()}/{qdata.game_size})*\n"
+                    message += f"__{qdata.full_game_name}__. *({qdata.queue.qsize()}/{qdata.game_size})*, "
                     dequeued.append(qdata)
             await self.update_ranked_display()
             if (len(dequeued) == 0):


### PR DESCRIPTION
Original:
[User]
removed from the queue for [Game] (X/X)
[User]
removed from the queue for [Game] (X/X)
[User]
removed from the queue for [Game] (X/X)

New:
[User]
removed from the queue for [Game] (X/X), [Game] (X/X), [Game] (X/X), 